### PR TITLE
Fix child page count to include unpublished pages

### DIFF
--- a/TemplateOncePerParent.module
+++ b/TemplateOncePerParent.module
@@ -36,7 +36,7 @@ class TemplateOncePerParent extends WireData implements Module {
 		
 		foreach(array_keys($templates) as $k) {
 			$template = $templates[$k];
-			if($template->oncePerParent && $parent->count("template={$template}") > 0) {
+			if($template->oncePerParent && $parent->numChildren("template={$template}, include=all") > 0) {
 				unset($templates[$k]);
 			}
 		}


### PR DESCRIPTION
For some reason, the `count` method always returns the number of all child pages. I got the correct result switching to `numChildren` and forcing `include=all`.